### PR TITLE
Small fixes and features

### DIFF
--- a/main.go
+++ b/main.go
@@ -92,8 +92,7 @@ func cacheReport(f func() ([]byte, error)) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		redisCon.Do("SET", "report", res)
-		redisCon.Do("EXPIRE", "report", 60)
+		redisCon.Do("SETEX", "report", 60, res)
 		data = res
 	} else {
 		log.Println("Using cached weather data")


### PR DESCRIPTION
1. Use `SETEX` instead of `SET` + `EXPIRE`. 
2. Allow to specify custom weather query string, `Cologne` is still default. 

http://currentweather-smira.gigantic.io/?q=London,uk

http://currentweather-smira.gigantic.io/?q=Moscow

With custom query string this looks as a microservice on its own: it caches openweather API results.