### PR TITLE
Fixed error handling for JSON unmarshalling.

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func getWeatherReport(query string) (WeatherReport, error) {
 		return report, err
 	}
 
-	if json.Unmarshal(data, &report); err != nil {
+	if err = json.Unmarshal(data, &report); err != nil {
 		return report, err
 	}
 


### PR DESCRIPTION
I noticed by accident, that getWeatherReport doesn't actually set err to the return value of json.Unmarshall before evaluating it. Fixed it for you :)

Regards,

David