### PR TITLE
OpenWeatherMap needs an API Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,7 @@ For further documentation and guides see the [docs](https://docs.giantswarm.io/)
 * [Python](https://github.com/giantswarm/giantswarm-firstapp-python)
 * [PHP](https://github.com/giantswarm/giantswarm-firstapp-php)
 * [Java](https://github.com/giantswarm/giantswarm-firstapp-java)
+
+## Open Weather API
+
+The weather data is provided by http://openweathermap.org

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 var redisCon redis.Conn
 
 const KelvinToCelsiusDiff = 273
+const OpenWeatherMapAPIKey = "182564eaf55f709a58a13c40086fb5bb"
 
 type WeatherReport struct {
 	Main struct {
@@ -87,7 +88,9 @@ func getWeatherReportData(query string) ([]byte, error) {
 		query = "Cologne,DE"
 	}
 
-	resp, err := http.Get("http://api.openweathermap.org/data/2.5/weather?q=" + url.QueryEscape(query))
+	url := fmt.Sprintf("http://api.openweathermap.org/data/2.5/weather?q=%v&appid=%v", url.QueryEscape(query), OpenWeatherMapAPIKey)
+
+	resp, err := http.Get(url)
 	if err != nil {
 		return data, err
 	}


### PR DESCRIPTION
I've created an OpenWeatherMap API Key and included it. As far as I can tell it's not prohibited to redistribute the key: http://openweathermap.org/price

It's currently limited to
```
Calls per minute (no more than)	60	600	3,000	30,000	200,000
Calls per day (no more than)	50,000
``` 
which might hit us some day. But currently it allows us to have the examples running without configuration need.
