### PR TITLE
fix unused import

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net"
 	"net/http"
 	"net/url"
 	"os"


### PR DESCRIPTION
current master is broken. the "net" import is not used anymore:

```
./main.go:9: imported and not used: "net"
```

this is the fix.